### PR TITLE
Remove # from AccountGroup factory names

### DIFF
--- a/spec/factories/account_groups.rb
+++ b/spec/factories/account_groups.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :account_group do
-    sequence(:name) { |n| "Group ##{n}" }
+    sequence(:name) { |n| "Group #{n}" }
   end
 end


### PR DESCRIPTION
Currently the Javascript doesn't handle these in account group names as
the account group name is used to generate HTML id attributes.

Screenshot from poltergeist reveals the accounts are not rendering on the dashboard, causing failures in `spec/features/dashboard_spec.rb`

![screenshot](https://cloud.githubusercontent.com/assets/169126/19803147/a61bd14c-9d63-11e6-8d16-7950f45088d4.png)

Bisected the failure to https://github.com/dotledger/dotledger/commit/cf8aee688cf643ba68f1e1af3a7648e3279f3a01