### PR TITLE
Use AccountGroup#id for HTML id on dashboard

### DIFF
--- a/app/assets/javascripts/dot_ledger/views/accounts/list.js.coffee
+++ b/app/assets/javascripts/dot_ledger/views/accounts/list.js.coffee
@@ -4,20 +4,22 @@ DotLedger.module 'Views.Accounts', ->
     template: 'accounts/list'
     getChildView: -> DotLedger.Views.Accounts.ListItem
     attachHtml: (collectionView, childView, index)->
-      list_id =  "account-group-#{s.underscored(childView.model.get('account_group_name'))}"
+      list_id = "account_group_#{childView.model.get('account_group_id')}"
       collectionView.$("div##{list_id}").append(childView.el)
     templateHelpers: ->
       accountGroups: =>
-        accountGroups = _.uniq(@collection.pluck('account_group_name'))
-        _.map accountGroups, (name)=>
+        accountGroups = {}
+        @collection.forEach (account)=>
+          accountGroups[account.get('account_group_id')] = account.get('account_group_name')
+        _.map accountGroups, (name, id)=>
           net = @collection.
             chain().
-            select((account)-> account.get('account_group_name') == name).
+            select((account)-> account.get('account_group_id') == id).
             map((account)-> account.get('balance')).
             reduce(((total, balance)->  total + parseFloat(balance)), 0.0).
             value()
           label: name
-          id: "account-group-#{s.underscored(name)}"
+          id: "account_group_#{id}"
           net: net
       totalCash: =>
         balances = @collection.map (account)->

--- a/spec/javascripts/dot_ledger/views/accounts/list_spec.js.coffee
+++ b/spec/javascripts/dot_ledger/views/accounts/list_spec.js.coffee
@@ -8,6 +8,7 @@ describe "DotLedger.Views.Accounts.List", ->
           balance: 10.00
           updated_at: '2013-01-01T01:00:00Z'
           unsorted_transaction_count: 0
+          account_group_id: '1'
           account_group_name: 'Group A'
         }
         {
@@ -16,6 +17,7 @@ describe "DotLedger.Views.Accounts.List", ->
           balance: 12.00
           updated_at: '2013-01-02T01:00:00Z'
           unsorted_transaction_count: 10
+          account_group_id: '1'
           account_group_name: 'Group A'
         }
         {
@@ -24,6 +26,7 @@ describe "DotLedger.Views.Accounts.List", ->
           balance: -12.00
           updated_at: '2013-01-03T01:00:00Z'
           unsorted_transaction_count: 12
+          account_group_id: '2'
           account_group_name: 'Group B'
         }
       ]


### PR DESCRIPTION
Fixes bug where if an AccountGroup name contains special characters
(e.g.  '#') related accounts do not display on the dashboard.

Fixes root cause of specs that were failing before #8
