### PR TITLE
Only allow poltergiest to connect to localhost

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,6 +56,10 @@ RSpec.configure do |config|
 
   config.infer_spec_type_from_file_location!
 
+  config.before(:each, js: true) do
+    page.driver.browser.url_whitelist = ["127.0.0.1"]
+  end
+
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
   end


### PR DESCRIPTION
_May_ be the solution to intermittent `Capybara::Poltergeist::StatusFailError` failures on Travis.  Could be timing out connecting to `fonts.gstatic.com` or other external service.  Is green on Travis for me but that might be just luck.  Should at least make the specs run a bit faster anyway.
