### PR TITLE
Docker Spec Container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,9 @@
 !config.ru
 !docker-entrypoint.sh
 !.ruby-version
+
+!docker-entrypoint.spec.sh
+!spec
+!.rspec
+!.rubocop.yml
+!Rakefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,17 @@ RUN apk --update add --no-cache --update --virtual build-dependencies \
    build-base ruby-dev postgresql-dev tzdata nodejs
 RUN gem install bundler && bundle install --without development test
 
-COPY . /app/
+COPY app /app/app
+COPY bin /app/bin
+COPY config /app/config
+COPY db /app/db
+COPY lib /app/lib
+COPY public /app/public
+COPY vendor /app/vendor
+COPY Rakefile /app/Rakefile
+COPY config.ru /app/config.ru
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+
 RUN chown -R nobody:nogroup /app/
 USER nobody
 

--- a/Dockerfile.spec
+++ b/Dockerfile.spec
@@ -1,0 +1,29 @@
+FROM dotledger_dotledger:latest
+
+USER root
+RUN chown -R root:root /app/
+
+RUN apk --update add fontconfig curl curl-dev
+
+ENV PHANTOMJS_ARCHIVE="phantomjs.tar.gz"
+
+RUN curl -Lk -o $PHANTOMJS_ARCHIVE https://github.com/fgrehm/docker-phantomjs2/releases/download/v2.0.0-20150722/dockerized-phantomjs.tar.gz \
+   && tar -xf $PHANTOMJS_ARCHIVE -C /tmp/ \
+   && cp -R /tmp/etc/fonts /etc/ \
+   && cp -R /tmp/lib/* /lib/ \
+   && cp -R /tmp/lib64 / \
+   && cp -R /tmp/usr/lib/* /usr/lib/ \
+   && cp -R /tmp/usr/lib/x86_64-linux-gnu /usr/ \
+   && cp -R /tmp/usr/share/* /usr/share/ \
+   && cp /tmp/usr/local/bin/phantomjs /usr/bin/ \
+   && rm -fr $PHANTOMJS_ARCHIVE /tmp/*
+
+RUN bundle install --with deveopment test
+
+COPY docker-entrypoint.spec.sh /app/docker-entrypoint.sh
+COPY spec /app/spec
+COPY .rspec /app/.rspec
+COPY .rubocop.yml /app/.rubocop.yml
+COPY Rakefile /app/Rakefile
+
+RUN echo "--force-color" >> /app/.rspec

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,3 +22,17 @@ services:
       RAILS_LOG_TO_STDOUT: 'true'
     ports:
       - '3000:3000'
+  spec:
+    build:
+      context: .
+      dockerfile: Dockerfile.spec
+    restart: 'no'
+    depends_on:
+      - postgres
+    links:
+      - postgres
+    environment:
+      DATABASE_URL: 'postgres://dot_ledger:dot_ledger@postgres/dot_ledger_test?sslmode=disable'
+      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: 'true'
+      RAILS_ENV: 'test'
+      LOG_LEVEL: 'DEBUG'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,11 @@ services:
     image: postgres:9.5
     restart: always
     environment:
-       POSTGRES_PASSWORD: dot_ledger
-       POSTGRES_USER: dot_ledger
-       POSTGRES_DB: dot_ledger
+      POSTGRES_PASSWORD: dot_ledger
+      POSTGRES_USER: dot_ledger
+      POSTGRES_DB: dot_ledger
     expose:
-      - "5432"
+      - '5432'
   dotledger:
     build: .
     restart: always
@@ -17,8 +17,8 @@ services:
     links:
       - postgres
     environment:
-      DATABASE_URL: "postgres://dot_ledger:dot_ledger@postgres/dot_ledger?sslmode=disable"
-      RAILS_SERVE_STATIC_FILES: "true"
-      RAILS_LOG_TO_STDOUT: "true"
+      DATABASE_URL: 'postgres://dot_ledger:dot_ledger@postgres/dot_ledger?sslmode=disable'
+      RAILS_SERVE_STATIC_FILES: 'true'
+      RAILS_LOG_TO_STDOUT: 'true'
     ports:
-      - "3000:3000"
+      - '3000:3000'

--- a/docker-entrypoint.spec.sh
+++ b/docker-entrypoint.spec.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+
+if [ "$#" -eq "0" ] ; then
+  bundle exec rake db:create
+  bundle exec rake db:test:prepare
+  bundle exec rspec
+else
+  exec "$@"
+fi


### PR DESCRIPTION
Not the best approach to specs, but it should help with upgrading gems and testing different versions of ruby.

I opted to create a new Dockerfile for specs, assuming the existing Dockerfile is for deploying.  Docker ignore files don't yet allow for a clean approach to differentiating between test containers and prod containers so I needed to tweak things a little on that front.